### PR TITLE
Copilot/breakdown streamed output methods

### DIFF
--- a/FluentXmlWriterCore/CustomXmlWriter.cs
+++ b/FluentXmlWriterCore/CustomXmlWriter.cs
@@ -5,8 +5,8 @@ namespace FluentXmlWriterCore;
 public class CustomXmlWriter
 	: XmlTextWriter
 {
-	public CustomXmlWriter(StringWriter sw, FormattingOptions? options = null)
-		: base(sw)
+	public CustomXmlWriter(TextWriter writer, FormattingOptions? options = null)
+		: base(writer)
 	{
 		var opts = options ?? FormattingOptions.Default;
 		

--- a/FluentXmlWriterCore/FluentXmlWriter.Complex.cs
+++ b/FluentXmlWriterCore/FluentXmlWriter.Complex.cs
@@ -172,16 +172,20 @@ partial class FluentXmlWriter
 
 	void IFluentXmlWriterComplex.Done()
 	{
-		if (_isStreamMode)
-		{
-			_xmlWriter.WriteEndElement(); // Top-level element
-			_xmlWriter.Flush();
-			_textWriter.Flush();
-			_textWriter.Dispose();
-		}
-		else
+		if (!_isStreamMode)
 		{
 			throw new InvalidOperationException("Done() can only be called when using stream-based mode. Use OutputToString() or OutputToFile() instead.");
 		}
+		
+		if (_isDone)
+		{
+			throw new InvalidOperationException("Done() has already been called on this FluentXmlWriter instance.");
+		}
+		
+		_xmlWriter.WriteEndElement(); // Top-level element
+		_xmlWriter.Flush();
+		_textWriter.Flush();
+		_textWriter.Dispose();
+		_isDone = true;
 	}
 }

--- a/FluentXmlWriterCore/FluentXmlWriter.Complex.cs
+++ b/FluentXmlWriterCore/FluentXmlWriter.Complex.cs
@@ -70,20 +70,32 @@ partial class FluentXmlWriter
 
 	void IFluentXmlWriterComplex.OutputToString(Action<string> action)
 	{
+		if (_isStreamMode)
+		{
+			throw new InvalidOperationException("OutputToString() cannot be called when using stream-based mode. Use Done() instead.");
+		}
 		_xmlWriter.WriteEndElement(); // Top-level element
-		action(_stringBuilder.ToString());
+		action(_stringBuilder!.ToString());
 	}
 
 	string IFluentXmlWriterComplex.OutputToString()
 	{
+		if (_isStreamMode)
+		{
+			throw new InvalidOperationException("OutputToString() cannot be called when using stream-based mode. Use Done() instead.");
+		}
 		_xmlWriter.WriteEndElement(); // Top-level element
-		return _stringBuilder.ToString();
+		return _stringBuilder!.ToString();
 	}
 
 	string IFluentXmlWriterComplex.OutputToString(bool indented)
 	{
+		if (_isStreamMode)
+		{
+			throw new InvalidOperationException("OutputToString() cannot be called when using stream-based mode. Use Done() instead.");
+		}
 		_xmlWriter.WriteEndElement(); // Top-level element
-		var xml = _stringBuilder.ToString();
+		var xml = _stringBuilder!.ToString();
 		
 		if (!indented)
 		{
@@ -98,8 +110,12 @@ partial class FluentXmlWriter
 
 	string IFluentXmlWriterComplex.OutputToString(FormattingOptions options)
 	{
+		if (_isStreamMode)
+		{
+			throw new InvalidOperationException("OutputToString() cannot be called when using stream-based mode. Use Done() instead.");
+		}
 		_xmlWriter.WriteEndElement(); // Top-level element
-		var xml = _stringBuilder.ToString();
+		var xml = _stringBuilder!.ToString();
 		
 		if (!options.Indent)
 		{
@@ -111,19 +127,61 @@ partial class FluentXmlWriter
 
 	void IFluentXmlWriterComplex.OutputToFile(string fileName)
 	{
+		if (_isStreamMode)
+		{
+			throw new InvalidOperationException("OutputToFile() cannot be called when using stream-based mode. Use Done() instead.");
+		}
 		_xmlWriter.WriteEndElement(); // Top-level element
-		File.WriteAllText(fileName, _stringBuilder.ToString());
+		File.WriteAllText(fileName, _stringBuilder!.ToString());
 	}
 
 	void IFluentXmlWriterComplex.OutputToFile(string fileName, bool indented)
 	{
+		if (_isStreamMode)
+		{
+			throw new InvalidOperationException("OutputToFile() cannot be called when using stream-based mode. Use Done() instead.");
+		}
 		var output = ((IFluentXmlWriterComplex)this).OutputToString(indented);
 		File.WriteAllText(fileName, output);
 	}
 
 	void IFluentXmlWriterComplex.OutputToFile(string fileName, FormattingOptions options)
 	{
+		if (_isStreamMode)
+		{
+			throw new InvalidOperationException("OutputToFile() cannot be called when using stream-based mode. Use Done() instead.");
+		}
 		var output = ((IFluentXmlWriterComplex)this).OutputToString(options);
 		File.WriteAllText(fileName, output);
+	}
+
+	string IFluentXmlWriterComplex.WriteToString()
+	{
+		return ((IFluentXmlWriterComplex)this).OutputToString();
+	}
+
+	string IFluentXmlWriterComplex.WriteToString(bool indented)
+	{
+		return ((IFluentXmlWriterComplex)this).OutputToString(indented);
+	}
+
+	string IFluentXmlWriterComplex.WriteToString(FormattingOptions options)
+	{
+		return ((IFluentXmlWriterComplex)this).OutputToString(options);
+	}
+
+	void IFluentXmlWriterComplex.Done()
+	{
+		if (_isStreamMode)
+		{
+			_xmlWriter.WriteEndElement(); // Top-level element
+			_xmlWriter.Flush();
+			_textWriter.Flush();
+			_textWriter.Dispose();
+		}
+		else
+		{
+			throw new InvalidOperationException("Done() can only be called when using stream-based mode. Use OutputToString() or OutputToFile() instead.");
+		}
 	}
 }

--- a/FluentXmlWriterCore/FluentXmlWriter.Complex.cs
+++ b/FluentXmlWriterCore/FluentXmlWriter.Complex.cs
@@ -185,7 +185,13 @@ partial class FluentXmlWriter
 		_xmlWriter.WriteEndElement(); // Top-level element
 		_xmlWriter.Flush();
 		_textWriter.Flush();
-		_textWriter.Dispose();
+		
+		// Only dispose the TextWriter if we created it (from a Stream)
+		if (_ownsTextWriter)
+		{
+			_textWriter.Dispose();
+		}
+		
 		_isDone = true;
 	}
 }

--- a/FluentXmlWriterCore/FluentXmlWriter.Simple.cs
+++ b/FluentXmlWriterCore/FluentXmlWriter.Simple.cs
@@ -69,23 +69,35 @@ partial class FluentXmlWriter
 
 	void IFluentXmlWriterSimple.OutputToString(Action<string> action)
 	{
+		if (_isStreamMode)
+		{
+			throw new InvalidOperationException("OutputToString() cannot be called when using stream-based mode. Use Done() instead.");
+		}
 		_xmlWriter.WriteEndElement(); // ends the simple element
 		_xmlWriter.WriteEndElement(); // Top-level element
-		action(_stringBuilder.ToString());
+		action(_stringBuilder!.ToString());
 	}
 
 	string IFluentXmlWriterSimple.OutputToString()
 	{
+		if (_isStreamMode)
+		{
+			throw new InvalidOperationException("OutputToString() cannot be called when using stream-based mode. Use Done() instead.");
+		}
 		_xmlWriter.WriteEndElement(); // ends the simple element
 		_xmlWriter.WriteEndElement(); // Top-level element
-		return _stringBuilder.ToString();
+		return _stringBuilder!.ToString();
 	}
 
 	string IFluentXmlWriterSimple.OutputToString(bool indented)
 	{
+		if (_isStreamMode)
+		{
+			throw new InvalidOperationException("OutputToString() cannot be called when using stream-based mode. Use Done() instead.");
+		}
 		_xmlWriter.WriteEndElement(); // ends the simple element
 		_xmlWriter.WriteEndElement(); // Top-level element
-		var xml = _stringBuilder.ToString();
+		var xml = _stringBuilder!.ToString();
 		
 		if (!indented)
 		{
@@ -100,9 +112,13 @@ partial class FluentXmlWriter
 
 	string IFluentXmlWriterSimple.OutputToString(FormattingOptions options)
 	{
+		if (_isStreamMode)
+		{
+			throw new InvalidOperationException("OutputToString() cannot be called when using stream-based mode. Use Done() instead.");
+		}
 		_xmlWriter.WriteEndElement(); // ends the simple element
 		_xmlWriter.WriteEndElement(); // Top-level element
-		var xml = _stringBuilder.ToString();
+		var xml = _stringBuilder!.ToString();
 		
 		if (!options.Indent)
 		{
@@ -114,20 +130,63 @@ partial class FluentXmlWriter
 
 	void IFluentXmlWriterSimple.OutputToFile(string fileName)
 	{
+		if (_isStreamMode)
+		{
+			throw new InvalidOperationException("OutputToFile() cannot be called when using stream-based mode. Use Done() instead.");
+		}
 		_xmlWriter.WriteEndElement(); // ends the simple element
 		_xmlWriter.WriteEndElement(); // Top-level element
-		File.WriteAllText(fileName, _stringBuilder.ToString());
+		File.WriteAllText(fileName, _stringBuilder!.ToString());
 	}
 
 	void IFluentXmlWriterSimple.OutputToFile(string fileName, bool indented)
 	{
+		if (_isStreamMode)
+		{
+			throw new InvalidOperationException("OutputToFile() cannot be called when using stream-based mode. Use Done() instead.");
+		}
 		var output = ((IFluentXmlWriterSimple)this).OutputToString(indented);
 		File.WriteAllText(fileName, output);
 	}
 
 	void IFluentXmlWriterSimple.OutputToFile(string fileName, FormattingOptions options)
 	{
+		if (_isStreamMode)
+		{
+			throw new InvalidOperationException("OutputToFile() cannot be called when using stream-based mode. Use Done() instead.");
+		}
 		var output = ((IFluentXmlWriterSimple)this).OutputToString(options);
 		File.WriteAllText(fileName, output);
+	}
+
+	string IFluentXmlWriterSimple.WriteToString()
+	{
+		return ((IFluentXmlWriterSimple)this).OutputToString();
+	}
+
+	string IFluentXmlWriterSimple.WriteToString(bool indented)
+	{
+		return ((IFluentXmlWriterSimple)this).OutputToString(indented);
+	}
+
+	string IFluentXmlWriterSimple.WriteToString(FormattingOptions options)
+	{
+		return ((IFluentXmlWriterSimple)this).OutputToString(options);
+	}
+
+	void IFluentXmlWriterSimple.Done()
+	{
+		if (_isStreamMode)
+		{
+			_xmlWriter.WriteEndElement(); // ends the simple element
+			_xmlWriter.WriteEndElement(); // Top-level element
+			_xmlWriter.Flush();
+			_textWriter.Flush();
+			_textWriter.Dispose();
+		}
+		else
+		{
+			throw new InvalidOperationException("Done() can only be called when using stream-based mode. Use OutputToString() or OutputToFile() instead.");
+		}
 	}
 }

--- a/FluentXmlWriterCore/FluentXmlWriter.Simple.cs
+++ b/FluentXmlWriterCore/FluentXmlWriter.Simple.cs
@@ -176,17 +176,21 @@ partial class FluentXmlWriter
 
 	void IFluentXmlWriterSimple.Done()
 	{
-		if (_isStreamMode)
-		{
-			_xmlWriter.WriteEndElement(); // ends the simple element
-			_xmlWriter.WriteEndElement(); // Top-level element
-			_xmlWriter.Flush();
-			_textWriter.Flush();
-			_textWriter.Dispose();
-		}
-		else
+		if (!_isStreamMode)
 		{
 			throw new InvalidOperationException("Done() can only be called when using stream-based mode. Use OutputToString() or OutputToFile() instead.");
 		}
+		
+		if (_isDone)
+		{
+			throw new InvalidOperationException("Done() has already been called on this FluentXmlWriter instance.");
+		}
+		
+		_xmlWriter.WriteEndElement(); // ends the simple element
+		_xmlWriter.WriteEndElement(); // Top-level element
+		_xmlWriter.Flush();
+		_textWriter.Flush();
+		_textWriter.Dispose();
+		_isDone = true;
 	}
 }

--- a/FluentXmlWriterCore/FluentXmlWriter.Simple.cs
+++ b/FluentXmlWriterCore/FluentXmlWriter.Simple.cs
@@ -190,7 +190,13 @@ partial class FluentXmlWriter
 		_xmlWriter.WriteEndElement(); // Top-level element
 		_xmlWriter.Flush();
 		_textWriter.Flush();
-		_textWriter.Dispose();
+		
+		// Only dispose the TextWriter if we created it (from a Stream)
+		if (_ownsTextWriter)
+		{
+			_textWriter.Dispose();
+		}
+		
 		_isDone = true;
 	}
 }

--- a/FluentXmlWriterCore/FluentXmlWriter.cs
+++ b/FluentXmlWriterCore/FluentXmlWriter.cs
@@ -10,6 +10,7 @@ public partial class FluentXmlWriter
 	private readonly TextWriter _textWriter;
 	private readonly XmlWriter _xmlWriter;
 	private readonly bool _isStreamMode;
+	private bool _isDone;
 
 	private FluentXmlWriter(FormattingOptions? options)
 	{
@@ -17,6 +18,7 @@ public partial class FluentXmlWriter
 		_textWriter = new StringWriter(_stringBuilder);
 		_xmlWriter = new CustomXmlWriter(_textWriter, options);
 		_isStreamMode = false;
+		_isDone = false;
 	}
 
 	private FluentXmlWriter(FluentXmlWriter writer)
@@ -25,6 +27,7 @@ public partial class FluentXmlWriter
 		_textWriter = writer._textWriter;
 		_xmlWriter = writer._xmlWriter;
 		_isStreamMode = writer._isStreamMode;
+		_isDone = writer._isDone;
 	}
 
 	private FluentXmlWriter(TextWriter textWriter, FormattingOptions? options, bool isStreamMode)
@@ -33,6 +36,7 @@ public partial class FluentXmlWriter
 		_textWriter = textWriter;
 		_xmlWriter = new CustomXmlWriter(_textWriter, options);
 		_isStreamMode = isStreamMode;
+		_isDone = false;
 	}
 
 	public static IFluentXmlWriterComplex Start(string topLevelElement)
@@ -56,17 +60,17 @@ public partial class FluentXmlWriter
 		return fluentXmlWriter.Complex(topLevelElement);
 	}
 
-	public static IFluentXmlWriterComplex Start(TextWriter textWriter, FormattingOptions? options = null)
+	public static IFluentXmlWriterComplex Start(TextWriter textWriter, string topLevelElement, FormattingOptions? options = null)
 	{
 		IFluentXmlWriterComplex fluentXmlWriter = new FluentXmlWriter(textWriter, options, true);
-		return fluentXmlWriter;
+		return fluentXmlWriter.Complex(topLevelElement);
 	}
 
-	public static IFluentXmlWriterComplex Start(Stream stream, FormattingOptions? options = null, Encoding? encoding = null)
+	public static IFluentXmlWriterComplex Start(Stream stream, string topLevelElement, FormattingOptions? options = null, Encoding? encoding = null)
 	{
 		var streamWriter = new StreamWriter(stream, encoding ?? Encoding.UTF8);
 		IFluentXmlWriterComplex fluentXmlWriter = new FluentXmlWriter(streamWriter, options, true);
-		return fluentXmlWriter;
+		return fluentXmlWriter.Complex(topLevelElement);
 	}
 
 	public override string ToString() => _stringBuilder?.ToString() ?? string.Empty;

--- a/FluentXmlWriterCore/FluentXmlWriter.cs
+++ b/FluentXmlWriterCore/FluentXmlWriter.cs
@@ -6,35 +6,44 @@ namespace FluentXmlWriterCore;
 public partial class FluentXmlWriter
 	: IDisposable, IFluentXmlWriterComplex, IFluentXmlWriterSimple
 {
-	private readonly StringBuilder _stringBuilder;
-	private readonly StringWriter _stringWriter;
+	private readonly StringBuilder? _stringBuilder;
+	private readonly TextWriter _textWriter;
 	private readonly XmlWriter _xmlWriter;
+	private readonly bool _isStreamMode;
 
-	private FluentXmlWriter(FluentXmlWriter? writer, FormattingOptions? options = null)
+	private FluentXmlWriter(FormattingOptions? options)
 	{
-		if (writer is null)
-		{
-			_stringBuilder = new StringBuilder();
-			_stringWriter = new StringWriter(_stringBuilder);
-			_xmlWriter = new CustomXmlWriter(_stringWriter, options);
-		}
-		else
-		{
-			_stringBuilder = writer._stringBuilder;
-			_stringWriter = writer._stringWriter;
-			_xmlWriter = writer._xmlWriter;
-		}
+		_stringBuilder = new StringBuilder();
+		_textWriter = new StringWriter(_stringBuilder);
+		_xmlWriter = new CustomXmlWriter(_textWriter, options);
+		_isStreamMode = false;
+	}
+
+	private FluentXmlWriter(FluentXmlWriter writer)
+	{
+		_stringBuilder = writer._stringBuilder;
+		_textWriter = writer._textWriter;
+		_xmlWriter = writer._xmlWriter;
+		_isStreamMode = writer._isStreamMode;
+	}
+
+	private FluentXmlWriter(TextWriter textWriter, FormattingOptions? options, bool isStreamMode)
+	{
+		_stringBuilder = null;
+		_textWriter = textWriter;
+		_xmlWriter = new CustomXmlWriter(_textWriter, options);
+		_isStreamMode = isStreamMode;
 	}
 
 	public static IFluentXmlWriterComplex Start(string topLevelElement)
 	{
-		IFluentXmlWriterComplex fluentXmlWriter = new FluentXmlWriter(null);
+		IFluentXmlWriterComplex fluentXmlWriter = new FluentXmlWriter((FormattingOptions?)null);
 		return fluentXmlWriter.Complex(topLevelElement);
 	}
 
 	public static IFluentXmlWriterComplex Start(string topLevelElement, FormattingOptions options)
 	{
-		IFluentXmlWriterComplex fluentXmlWriter = new FluentXmlWriter(null, options);
+		IFluentXmlWriterComplex fluentXmlWriter = new FluentXmlWriter(options);
 		return fluentXmlWriter.Complex(topLevelElement);
 	}
 
@@ -43,11 +52,24 @@ public partial class FluentXmlWriter
 		var options = indented 
 			? FormattingOptions.Default.WithTabs().WithNewLine(Environment.NewLine)
 			: FormattingOptions.Default;
-		IFluentXmlWriterComplex fluentXmlWriter = new FluentXmlWriter(null, options);
+		IFluentXmlWriterComplex fluentXmlWriter = new FluentXmlWriter(options);
 		return fluentXmlWriter.Complex(topLevelElement);
 	}
 
-	public override string ToString() => _stringBuilder.ToString();
+	public static IFluentXmlWriterComplex Start(TextWriter textWriter, FormattingOptions? options = null)
+	{
+		IFluentXmlWriterComplex fluentXmlWriter = new FluentXmlWriter(textWriter, options, true);
+		return fluentXmlWriter;
+	}
+
+	public static IFluentXmlWriterComplex Start(Stream stream, FormattingOptions? options = null, Encoding? encoding = null)
+	{
+		var streamWriter = new StreamWriter(stream, encoding ?? Encoding.UTF8);
+		IFluentXmlWriterComplex fluentXmlWriter = new FluentXmlWriter(streamWriter, options, true);
+		return fluentXmlWriter;
+	}
+
+	public override string ToString() => _stringBuilder?.ToString() ?? string.Empty;
 
 	void IDisposable.Dispose() => ((IDisposable)_xmlWriter).Dispose();
 

--- a/FluentXmlWriterCore/FluentXmlWriter.cs
+++ b/FluentXmlWriterCore/FluentXmlWriter.cs
@@ -10,6 +10,7 @@ public partial class FluentXmlWriter
 	private readonly TextWriter _textWriter;
 	private readonly XmlWriter _xmlWriter;
 	private readonly bool _isStreamMode;
+	private readonly bool _ownsTextWriter;
 	private bool _isDone;
 
 	private FluentXmlWriter(FormattingOptions? options)
@@ -18,6 +19,7 @@ public partial class FluentXmlWriter
 		_textWriter = new StringWriter(_stringBuilder);
 		_xmlWriter = new CustomXmlWriter(_textWriter, options);
 		_isStreamMode = false;
+		_ownsTextWriter = true;
 		_isDone = false;
 	}
 
@@ -27,15 +29,17 @@ public partial class FluentXmlWriter
 		_textWriter = writer._textWriter;
 		_xmlWriter = writer._xmlWriter;
 		_isStreamMode = writer._isStreamMode;
+		_ownsTextWriter = writer._ownsTextWriter;
 		_isDone = writer._isDone;
 	}
 
-	private FluentXmlWriter(TextWriter textWriter, FormattingOptions? options, bool isStreamMode)
+	private FluentXmlWriter(TextWriter textWriter, FormattingOptions? options, bool isStreamMode, bool ownsTextWriter)
 	{
 		_stringBuilder = null;
 		_textWriter = textWriter;
 		_xmlWriter = new CustomXmlWriter(_textWriter, options);
 		_isStreamMode = isStreamMode;
+		_ownsTextWriter = ownsTextWriter;
 		_isDone = false;
 	}
 
@@ -62,14 +66,14 @@ public partial class FluentXmlWriter
 
 	public static IFluentXmlWriterComplex Start(TextWriter textWriter, string topLevelElement, FormattingOptions? options = null)
 	{
-		IFluentXmlWriterComplex fluentXmlWriter = new FluentXmlWriter(textWriter, options, true);
+		IFluentXmlWriterComplex fluentXmlWriter = new FluentXmlWriter(textWriter, options, true, false);
 		return fluentXmlWriter.Complex(topLevelElement);
 	}
 
 	public static IFluentXmlWriterComplex Start(Stream stream, string topLevelElement, FormattingOptions? options = null, Encoding? encoding = null)
 	{
 		var streamWriter = new StreamWriter(stream, encoding ?? Encoding.UTF8);
-		IFluentXmlWriterComplex fluentXmlWriter = new FluentXmlWriter(streamWriter, options, true);
+		IFluentXmlWriterComplex fluentXmlWriter = new FluentXmlWriter(streamWriter, options, true, true);
 		return fluentXmlWriter.Complex(topLevelElement);
 	}
 

--- a/FluentXmlWriterCore/FluentXmlWriter.cs
+++ b/FluentXmlWriterCore/FluentXmlWriter.cs
@@ -23,16 +23,6 @@ public partial class FluentXmlWriter
 		_isDone = false;
 	}
 
-	private FluentXmlWriter(FluentXmlWriter writer)
-	{
-		_stringBuilder = writer._stringBuilder;
-		_textWriter = writer._textWriter;
-		_xmlWriter = writer._xmlWriter;
-		_isStreamMode = writer._isStreamMode;
-		_ownsTextWriter = writer._ownsTextWriter;
-		_isDone = writer._isDone;
-	}
-
 	private FluentXmlWriter(TextWriter textWriter, FormattingOptions? options, bool isStreamMode, bool ownsTextWriter)
 	{
 		_stringBuilder = null;

--- a/FluentXmlWriterCore/IFluentXmlWriterComplex.cs
+++ b/FluentXmlWriterCore/IFluentXmlWriterComplex.cs
@@ -18,5 +18,9 @@ public interface IFluentXmlWriterComplex
 	void OutputToFile(string fileName);
 	void OutputToFile(string fileName, bool indented);
 	void OutputToFile(string fileName, FormattingOptions options);
+	string WriteToString();
+	string WriteToString(bool indented);
+	string WriteToString(FormattingOptions options);
+	void Done();
 }
 // TODO: Conditionals (ex: SimpleIf(someCond, ...))

--- a/FluentXmlWriterCore/IFluentXmlWriterSimple.cs
+++ b/FluentXmlWriterCore/IFluentXmlWriterSimple.cs
@@ -18,5 +18,9 @@ public interface IFluentXmlWriterSimple
 	void OutputToFile(string fileName);
 	void OutputToFile(string fileName, bool indented);
 	void OutputToFile(string fileName, FormattingOptions options);
+	string WriteToString();
+	string WriteToString(bool indented);
+	string WriteToString(FormattingOptions options);
+	void Done();
 }
 // TODO: Conditionals

--- a/FluentXmlWriterTests/StreamBasedTests.cs
+++ b/FluentXmlWriterTests/StreamBasedTests.cs
@@ -231,4 +231,43 @@ public class StreamBasedTests
 
 		Assert.ThrowsException<InvalidOperationException>(() => writer.Done());
 	}
+
+	[TestMethod]
+	public void TestStreamBasedWithTextWriter_DoesNotDisposeTextWriter()
+	{
+		var stringWriter = new StringWriter();
+		
+		FluentXmlWriter.Start(stringWriter, "top", FormattingOptions.Default)
+			.Complex("child").Text("value").EndElem()
+			.Done();
+
+		// Should still be able to use the StringWriter after Done()
+		stringWriter.Write(" extra");
+		var result = stringWriter.ToString();
+		Assert.IsTrue(result.Contains("extra"));
+		
+		stringWriter.Dispose();
+	}
+
+	[TestMethod]
+	public void TestStreamBasedWithStream_DisposesStreamWriter()
+	{
+		var tempFile = Path.GetTempFileName();
+		try
+		{
+			var fileStream = File.Create(tempFile);
+			
+			FluentXmlWriter.Start(fileStream, "root", FormattingOptions.Default)
+				.Complex("child").Text("value").EndElem()
+				.Done();
+
+			// The fileStream should be closed now (through the disposed StreamWriter)
+			// Attempting to write should throw
+			Assert.ThrowsException<ObjectDisposedException>(() => fileStream.WriteByte(0));
+		}
+		finally
+		{
+			File.Delete(tempFile);
+		}
+	}
 }

--- a/FluentXmlWriterTests/StreamBasedTests.cs
+++ b/FluentXmlWriterTests/StreamBasedTests.cs
@@ -235,7 +235,7 @@ public class StreamBasedTests
 	[TestMethod]
 	public void TestStreamBasedWithTextWriter_DoesNotDisposeTextWriter()
 	{
-		var stringWriter = new StringWriter();
+		using var stringWriter = new StringWriter();
 		
 		FluentXmlWriter.Start(stringWriter, "top", FormattingOptions.Default)
 			.Complex("child").Text("value").EndElem()
@@ -245,8 +245,6 @@ public class StreamBasedTests
 		stringWriter.Write(" extra");
 		var result = stringWriter.ToString();
 		Assert.IsTrue(result.Contains("extra"));
-		
-		stringWriter.Dispose();
 	}
 
 	[TestMethod]

--- a/FluentXmlWriterTests/StreamBasedTests.cs
+++ b/FluentXmlWriterTests/StreamBasedTests.cs
@@ -11,8 +11,7 @@ public class StreamBasedTests
 	{
 		using var stringWriter = new StringWriter();
 		
-		FluentXmlWriter.Start(stringWriter, FormattingOptions.Default)
-			.Complex("top")
+		FluentXmlWriter.Start(stringWriter, "top", FormattingOptions.Default)
 			.ManySimple(
 				SimpleElement.Create("a").Attr("id", "1"),
 				SimpleElement.Create("b").Attr("id", "2")
@@ -32,8 +31,7 @@ public class StreamBasedTests
 			.WithTabs()
 			.WithNewLine(Environment.NewLine);
 		
-		FluentXmlWriter.Start(stringWriter, options)
-			.Complex("top")
+		FluentXmlWriter.Start(stringWriter, "top", options)
 			.ManySimple(
 				SimpleElement.Create("a").Attr("id", "1"),
 				SimpleElement.Create("b").Attr("id", "2")
@@ -56,8 +54,7 @@ public class StreamBasedTests
 		{
 			using (var fileStream = File.Create(tempFile))
 			{
-				FluentXmlWriter.Start(fileStream, FormattingOptions.Default)
-					.Complex("root")
+				FluentXmlWriter.Start(fileStream, "root", FormattingOptions.Default)
 					.Complex("child").Text("value").EndElem()
 					.Done();
 			}
@@ -84,8 +81,7 @@ public class StreamBasedTests
 			
 			using (var fileStream = File.Create(tempFile))
 			{
-				FluentXmlWriter.Start(fileStream, options)
-					.Complex("root")
+				FluentXmlWriter.Start(fileStream, "root", options)
 					.Complex("child").Text("value").EndElem()
 					.Done();
 			}
@@ -108,8 +104,7 @@ public class StreamBasedTests
 		{
 			using (var fileStream = File.Create(tempFile))
 			{
-				FluentXmlWriter.Start(fileStream, FormattingOptions.Default, Encoding.UTF8)
-					.Complex("root")
+				FluentXmlWriter.Start(fileStream, "root", FormattingOptions.Default, Encoding.UTF8)
 					.Complex("child").Text("Hello 世界").EndElem()
 					.Done();
 			}
@@ -129,8 +124,7 @@ public class StreamBasedTests
 	{
 		using var stringWriter = new StringWriter();
 		
-		var writer = FluentXmlWriter.Start(stringWriter, FormattingOptions.Default)
-			.Complex("top");
+		var writer = FluentXmlWriter.Start(stringWriter, "top", FormattingOptions.Default);
 
 		Assert.ThrowsException<InvalidOperationException>(() => writer.OutputToString());
 	}
@@ -140,8 +134,7 @@ public class StreamBasedTests
 	{
 		using var stringWriter = new StringWriter();
 		
-		var writer = FluentXmlWriter.Start(stringWriter, FormattingOptions.Default)
-			.Complex("top");
+		var writer = FluentXmlWriter.Start(stringWriter, "top", FormattingOptions.Default);
 
 		Assert.ThrowsException<InvalidOperationException>(() => writer.OutputToFile("test.xml"));
 	}
@@ -213,8 +206,7 @@ public class StreamBasedTests
 			.WithSpaces(2)
 			.WithNewLine("\n");
 		
-		FluentXmlWriter.Start(stringWriter, options)
-			.Complex("response")
+		FluentXmlWriter.Start(stringWriter, "response", options)
 			.Attr("status", "success")
 			.Complex("data")
 				.Complex("user")
@@ -227,5 +219,16 @@ public class StreamBasedTests
 		var xml = stringWriter.ToString();
 		const string expected = "<response status=\"success\">\n  <data>\n    <user>\n      <id>123</id>\n      <name>John</name>\n    </user>\n  </data>\n</response>";
 		Assert.AreEqual(expected, xml);
+	}
+
+	[TestMethod]
+	public void TestStreamMode_CannotCallDoneTwice()
+	{
+		using var stringWriter = new StringWriter();
+		
+		var writer = FluentXmlWriter.Start(stringWriter, "top", FormattingOptions.Default);
+		writer.Done();
+
+		Assert.ThrowsException<InvalidOperationException>(() => writer.Done());
 	}
 }

--- a/FluentXmlWriterTests/StreamBasedTests.cs
+++ b/FluentXmlWriterTests/StreamBasedTests.cs
@@ -1,0 +1,231 @@
+using System.Text;
+using FluentXmlWriterCore;
+
+namespace FluentXmlWriterTests;
+
+[TestClass]
+public class StreamBasedTests
+{
+	[TestMethod]
+	public void TestStreamBasedWithTextWriter()
+	{
+		using var stringWriter = new StringWriter();
+		
+		FluentXmlWriter.Start(stringWriter, FormattingOptions.Default)
+			.Complex("top")
+			.ManySimple(
+				SimpleElement.Create("a").Attr("id", "1"),
+				SimpleElement.Create("b").Attr("id", "2")
+			)
+			.Done();
+
+		var xml = stringWriter.ToString();
+		const string expected = "<top><a id=\"1\" /><b id=\"2\" /></top>";
+		Assert.AreEqual(expected, xml);
+	}
+
+	[TestMethod]
+	public void TestStreamBasedWithTextWriter_Indented()
+	{
+		using var stringWriter = new StringWriter();
+		var options = FormattingOptions.Default
+			.WithTabs()
+			.WithNewLine(Environment.NewLine);
+		
+		FluentXmlWriter.Start(stringWriter, options)
+			.Complex("top")
+			.ManySimple(
+				SimpleElement.Create("a").Attr("id", "1"),
+				SimpleElement.Create("b").Attr("id", "2")
+			)
+			.Done();
+
+		var xml = stringWriter.ToString();
+		var expected = "<top>" + Environment.NewLine +
+			"\t<a id=\"1\" />" + Environment.NewLine +
+			"\t<b id=\"2\" />" + Environment.NewLine +
+			"</top>";
+		Assert.AreEqual(expected, xml);
+	}
+
+	[TestMethod]
+	public void TestStreamBasedWithFileStream()
+	{
+		var tempFile = Path.GetTempFileName();
+		try
+		{
+			using (var fileStream = File.Create(tempFile))
+			{
+				FluentXmlWriter.Start(fileStream, FormattingOptions.Default)
+					.Complex("root")
+					.Complex("child").Text("value").EndElem()
+					.Done();
+			}
+
+			var xml = File.ReadAllText(tempFile);
+			const string expected = "<root><child>value</child></root>";
+			Assert.AreEqual(expected, xml);
+		}
+		finally
+		{
+			File.Delete(tempFile);
+		}
+	}
+
+	[TestMethod]
+	public void TestStreamBasedWithFileStream_Indented()
+	{
+		var tempFile = Path.GetTempFileName();
+		try
+		{
+			var options = FormattingOptions.Default
+				.WithSpaces(2)
+				.WithNewLine("\n");
+			
+			using (var fileStream = File.Create(tempFile))
+			{
+				FluentXmlWriter.Start(fileStream, options)
+					.Complex("root")
+					.Complex("child").Text("value").EndElem()
+					.Done();
+			}
+
+			var xml = File.ReadAllText(tempFile);
+			const string expected = "<root>\n  <child>value</child>\n</root>";
+			Assert.AreEqual(expected, xml);
+		}
+		finally
+		{
+			File.Delete(tempFile);
+		}
+	}
+
+	[TestMethod]
+	public void TestStreamBasedWithFileStream_UTF8Encoding()
+	{
+		var tempFile = Path.GetTempFileName();
+		try
+		{
+			using (var fileStream = File.Create(tempFile))
+			{
+				FluentXmlWriter.Start(fileStream, FormattingOptions.Default, Encoding.UTF8)
+					.Complex("root")
+					.Complex("child").Text("Hello 世界").EndElem()
+					.Done();
+			}
+
+			var xml = File.ReadAllText(tempFile, Encoding.UTF8);
+			const string expected = "<root><child>Hello 世界</child></root>";
+			Assert.AreEqual(expected, xml);
+		}
+		finally
+		{
+			File.Delete(tempFile);
+		}
+	}
+
+	[TestMethod]
+	public void TestStreamMode_CannotCallOutputToString()
+	{
+		using var stringWriter = new StringWriter();
+		
+		var writer = FluentXmlWriter.Start(stringWriter, FormattingOptions.Default)
+			.Complex("top");
+
+		Assert.ThrowsException<InvalidOperationException>(() => writer.OutputToString());
+	}
+
+	[TestMethod]
+	public void TestStreamMode_CannotCallOutputToFile()
+	{
+		using var stringWriter = new StringWriter();
+		
+		var writer = FluentXmlWriter.Start(stringWriter, FormattingOptions.Default)
+			.Complex("top");
+
+		Assert.ThrowsException<InvalidOperationException>(() => writer.OutputToFile("test.xml"));
+	}
+
+	[TestMethod]
+	public void TestNormalMode_CannotCallDone()
+	{
+		var writer = FluentXmlWriter.Start("top");
+
+		Assert.ThrowsException<InvalidOperationException>(() => writer.Done());
+	}
+
+	[TestMethod]
+	public void TestWriteToString_BasicUsage()
+	{
+		var xml = FluentXmlWriter.Start("root")
+			.Complex("child").Text("value").EndElem()
+			.WriteToString();
+
+		const string expected = "<root><child>value</child></root>";
+		Assert.AreEqual(expected, xml);
+	}
+
+	[TestMethod]
+	public void TestWriteToString_WithIndentation()
+	{
+		var xml = FluentXmlWriter.Start("root")
+			.Complex("child").Text("value").EndElem()
+			.WriteToString(indented: true);
+
+		var expected = "<root>" + Environment.NewLine +
+			"\t<child>value</child>" + Environment.NewLine +
+			"</root>";
+		Assert.AreEqual(expected, xml);
+	}
+
+	[TestMethod]
+	public void TestWriteToString_WithFormattingOptions()
+	{
+		var xml = FluentXmlWriter.Start("root")
+			.Complex("child").Text("value").EndElem()
+			.WriteToString(FormattingOptions.Default
+				.WithSpaces(4)
+				.WithNewLine("\n"));
+
+		const string expected = "<root>\n    <child>value</child>\n</root>";
+		Assert.AreEqual(expected, xml);
+	}
+
+	[TestMethod]
+	public void TestWriteToString_WithSimpleElements()
+	{
+		var xml = FluentXmlWriter.Start("root")
+			.ManySimple(
+				SimpleElement.Create("a").Attr("id", "1"),
+				SimpleElement.Create("b").Attr("id", "2")
+			)
+			.WriteToString();
+
+		const string expected = "<root><a id=\"1\" /><b id=\"2\" /></root>";
+		Assert.AreEqual(expected, xml);
+	}
+
+	[TestMethod]
+	public void TestStreamBasedWithComplexStructure()
+	{
+		using var stringWriter = new StringWriter();
+		var options = FormattingOptions.Default
+			.WithSpaces(2)
+			.WithNewLine("\n");
+		
+		FluentXmlWriter.Start(stringWriter, options)
+			.Complex("response")
+			.Attr("status", "success")
+			.Complex("data")
+				.Complex("user")
+					.Complex("id").Text("123").EndElem()
+					.Complex("name").Text("John").EndElem()
+					.EndElem()
+				.EndElem()
+			.Done();
+
+		var xml = stringWriter.ToString();
+		const string expected = "<response status=\"success\">\n  <data>\n    <user>\n      <id>123</id>\n      <name>John</name>\n    </user>\n  </data>\n</response>";
+		Assert.AreEqual(expected, xml);
+	}
+}


### PR DESCRIPTION
Implements two distinct usage patterns: stream-based writing with explicit completion via Done(), and WriteToString() methods as cleaner alternatives to OutputToString().

# Changes
## Stream-based API
- Start(TextWriter, topLevelElement, FormattingOptions?) - writes directly to provided writer
- Start(Stream, topLevelElement, FormattingOptions?, Encoding?) - creates internal StreamWriter
- Done() - flushes and disposes stream (only disposes when we own the TextWriter)
- Prevents calling OutputToString()/OutputToFile() in stream mode
- Prevents multiple Done() calls with _isDone flag
##WriteToString() methods
- WriteToString(), WriteToString(bool), WriteToString(FormattingOptions)
- Delegates to existing OutputToString() implementation
##Internal changes
- CustomXmlWriter accepts any TextWriter (not just StringWriter)
- _isStreamMode and _ownsTextWriter flags control behavior and disposal
# Examples
## Stream-based writing:
```c#
using (var fileStream = File.Create("output.xml"))
{
    FluentXmlWriter.Start(fileStream, "root", FormattingOptions.Default.WithSpaces(2))
        .ManySimple(
            SimpleElement.Create("foo").Attr("id", "1"),
            SimpleElement.Create("bar").Attr("id", "2")
        )
        .Done(); // Flushes and disposes
}
```

String output:

```c#
string xml = FluentXmlWriter.Start("root")
    .Complex("child").Text("value").EndElem()
    .WriteToString(indented: true);
```

All existing API methods remain unchanged and functional. Added 16 tests covering new functionality.

# Original Prompt

For the first one, accept a stream in the Start method, and make a Done() method which flushes and disposees the underlying stream:

```c#
FluentXmlWriter.Start(File.CreateText(@"/filename.txt"), FormattingOptions.Default, Encoding.UTF8)
    .ManySimple(
        SimpleElement.Create("foo").Attr("id", "1"),
        SimpleElement.Create("bar").Attr("id", "2")
    ).Done(); // Done() flushes and disposes the file stream
```

For the second one, keep the OutputTo... methods. Instead of a StringBuilder/StringWriter, use a MemoryStream so that you can use the same underlying technology as the first one.

```c#
string xml = FluentXmlWriter.Start(File.CreateText(@"/filename.txt"), FormattingOptions.Default, Encoding.UTF8)
    .ManySimple(
        SimpleElement.Create("foo").Attr("id", "1"),
        SimpleElement.Create("bar").Attr("id", "2")
    ).WriteToString(); // Flushes the underlying memory stream and returns the output as a string.
```